### PR TITLE
[ACADEMY-166] Add automatic language detection, fix wrong hrefs in SE pages

### DIFF
--- a/aboutSE.html
+++ b/aboutSE.html
@@ -79,8 +79,8 @@
 							<img src="assets/img/flags/swe.png" alt="Sweden" class="flag" style="width: 32px;">
 						</a>
 						<ul>
-							<li><a href="contact.html">English</a></li>
-							<li><a href="contactBR.html">Português</a></li>
+							<li><a href="about.html">English</a></li>
+							<li><a href="aboutBR.html">Português</a></li>
 						</ul>
 					</li>
 				</ul>

--- a/academySE.html
+++ b/academySE.html
@@ -78,8 +78,8 @@
 							<img src="assets/img/flags/swe.png" alt="Sweden" class="flag" style="width: 32px;">
 						</a>
 						<ul>
-							<li><a href="contact.html">English</a></li>
-							<li><a href="contactBR.html">Português</a></li>
+							<li><a href="academy.html">English</a></li>
+							<li><a href="academyBR.html">Português</a></li>
 						</ul>
 					</li>
 				</ul>

--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -15,7 +15,6 @@ var $html = $('html');
 var $body = $('body');
 
 // Language selection trigger
-
 $('.language > ul > li > ul > li > a').on('click', (event) => {
     event.preventDefault();
     const selectedLang = $(event.target).html()
@@ -24,7 +23,6 @@ $('.language > ul > li > ul > li > a').on('click', (event) => {
 })
 
 // Default Language selection
-
 const localStorage = window.localStorage
 let userLanguage = localStorage.getItem('userLanguage')
 

--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -14,6 +14,57 @@ Author:         Suelo
 var $html = $('html');
 var $body = $('body');
 
+// Language selection trigger
+
+$('.language > ul > li > ul > li > a').on('click', (event) => {
+    event.preventDefault();
+    const selectedLang = $(event.target).html()
+    localStorage.setItem('userLanguage', selectedLang)
+    window.location.href = $(event.target).attr('href')
+})
+
+// Default Language selection
+
+const localStorage = window.localStorage
+let userLanguage = localStorage.getItem('userLanguage')
+
+let lang = window.navigator.languages ? window.navigator.languages[0] : null;
+lang = lang || window.navigator.language || window.navigator.browserLanguage || window.navigator.userLanguage;
+
+let shortLang = lang;
+if (shortLang.indexOf('-') !== -1)
+    shortLang = shortLang.split('-')[0];
+
+if (shortLang.indexOf('_') !== -1)
+    shortLang = shortLang.split('_')[0];
+
+const possibleLangs = { "pt": { "suffix": "BR", "fullName": "Português" }, 
+                        "sv": { "suffix": "SE", "fullName": "Svenska" },
+                        "en": { "suffix": "", "fullName": "English" }};
+
+ // If no language is selected, use browser language. If unsupported, use english.
+if (userLanguage === null) {
+    const selectedLang = !possibleLangs.hasOwnProperty(shortLang)
+                        ? "English"
+                        : possibleLangs[shortLang].fullName
+    localStorage.setItem('userLanguage', selectedLang);
+
+    // update user language after setting it up.
+    userLanguage = localStorage.getItem('userLanguage')
+}
+
+ // Redirect the user to the correct URL if necessary.
+$('.language * a').map((index, element) => {
+    const elementLanguage = $(element).html()
+    const elementRedirectURL = $(element).attr('href')
+    console.log($(element))
+    if (elementLanguage === userLanguage){
+        window.location.href = elementRedirectURL
+    }
+})
+
+
+
 /* Header Function */
 
 var $header = $('#header'),

--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -45,6 +45,7 @@ if (userLanguage === null) {
     const selectedLang = !possibleLangs.hasOwnProperty(shortLang)
                         ? "English"
                         : possibleLangs[shortLang].fullName
+                        
     localStorage.setItem('userLanguage', selectedLang);
 
     // update user language after setting it up.
@@ -55,7 +56,6 @@ if (userLanguage === null) {
 $('.language * a').map((index, element) => {
     const elementLanguage = $(element).html()
     const elementRedirectURL = $(element).attr('href')
-    console.log($(element))
     if (elementLanguage === userLanguage){
         window.location.href = elementRedirectURL
     }

--- a/indexSE.html
+++ b/indexSE.html
@@ -97,8 +97,8 @@
 							<img src="assets/img/flags/swe.png" alt="Sweden" class="flag" style="width: 32px;">
 						</a>
 						<ul>
-							<li><a href="contact.html">English</a></li>
-							<li><a href="contactBR.html">Português</a></li>
+							<li><a href="index.html">English</a></li>
+							<li><a href="indexBR.html">Português</a></li>
 						</ul>
 					</li>
 				</ul>


### PR DESCRIPTION
Implements [166](https://sebratec.atlassian.net/browse/ACADEMY-166)

Now all the pages of the website should automatically redirect to the user's browser language if it is available. If it's not, defaults to English. Also fixes a few incorrect links in the Swedish pages.

![More languages!](https://media.giphy.com/media/l2JdZGeSdUbjMJsDC/giphy.gif)

## Testing

- Open website, as usual. Verify which language it loads.
- Select a few different languages using the language selector in the top right navigation bar
- Manually change the browser URL to another language. For example: localhost/index.html --> localhost/indexBR.html
- Check if the website is behaving as it should.
- Manually change your browser language to an unsupported one, Italian, for example, and check if it defaults to English.
