### PR TITLE
[ACADEMY-167] Add hubspot tracking code

### DIFF
--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -61,7 +61,15 @@ $('.language * a').map((index, element) => {
     }
 })
 
+// include hubspot tracking script
 
+const imported = document.createElement('script');
+imported.src = '//js.hs-scripts.com/8334217.js';
+imported.id = "hs-script-loader"
+imported.setAttribute("async", "")
+imported.setAttribute("defer", "")
+imported.setAttribute("type", "text/javascript")
+document.body.appendChild(imported);
 
 /* Header Function */
 

--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -62,7 +62,6 @@ $('.language * a').map((index, element) => {
 })
 
 // include hubspot tracking script
-
 const imported = document.createElement('script');
 imported.src = '//js.hs-scripts.com/8334217.js';
 imported.id = "hs-script-loader"


### PR DESCRIPTION
Implements [167](https://sebratec.atlassian.net/browse/ACADEMY-167?atlOrigin=eyJpIjoiMTdmMTFlY2EzOTU4NGRmNDgxMDliMzQzMzM3YTZhYTUiLCJwIjoiaiJ9)

Added script for tracking the website analytics in HubSpot.

![marketing](https://media.giphy.com/media/mwwEcxbodLHIk/giphy.gif)

## Testing

- Open any page
- Open dev tools
- Check in the sources tab if the Hubspot script is being loaded (you might need to disable your adblocker)